### PR TITLE
Wrap filename in quotes to avoid open failure

### DIFF
--- a/src/features/proseLinter.ts
+++ b/src/features/proseLinter.ts
@@ -47,7 +47,7 @@ export default class ProseLinter implements vscode.CodeActionProvider {
     }
 
     public checkDocument(document: vscode.TextDocument = vscode.window.activeTextEditor.document) {
-        shelljs.exec(`proselint --json ${document.fileName}`, (code, output, error) => {
+        shelljs.exec(`proselint --json "${document.fileName}"`, (code, output, error) => {
             this.proseLintResult(document, code, output, error);
         });
     }


### PR DESCRIPTION
This fixes a bug where proselint fails when handling file paths which include spaces. The most common occurrence of this will probably be Mac users editing their VScode settings, but it can be a bother to users on any platform.

```
Traceback (most recent call last):
  File "/usr/local/Cellar/proselint/0.8.0/libexec/lib/python2.7/site-packages/proselint/command_line.py", line 138, in proselint
    f = click.open_file(fp, 'r', encoding="utf-8", errors="replace")
  File "/usr/local/Cellar/proselint/0.8.0/libexec/lib/python2.7/site-packages/click/utils.py", line 323, in open_file
    atomic=atomic)
  File "/usr/local/Cellar/proselint/0.8.0/libexec/lib/python2.7/site-packages/click/_compat.py", line 435, in open_stream
    return io.open(filename, mode, encoding=encoding, errors=errors), True
IOError: [Errno 2] No such file or directory: '/Users/c70b/Library/Application'
Traceback (most recent call last):
  File "/usr/local/Cellar/proselint/0.8.0/libexec/lib/python2.7/site-packages/proselint/command_line.py", line 138, in proselint
    f = click.open_file(fp, 'r', encoding="utf-8", errors="replace")
  File "/usr/local/Cellar/proselint/0.8.0/libexec/lib/python2.7/site-packages/click/utils.py", line 323, in open_file
    atomic=atomic)
  File "/usr/local/Cellar/proselint/0.8.0/libexec/lib/python2.7/site-packages/click/_compat.py", line 435, in open_stream
    return io.open(filename, mode, encoding=encoding, errors=errors), True
IOError: [Errno 2] No such file or directory: 'Support/Code/User/settings.json'
```